### PR TITLE
change order of items in playbook, to put important items nearer the top

### DIFF
--- a/antora-playbooks/antora-local-playbook.yaml
+++ b/antora-playbooks/antora-local-playbook.yaml
@@ -3,6 +3,18 @@ site:
   start_page: streaming::index.adoc
   url: https://docs.datastax.com/en/streaming
 
+output:
+  dir: '~/work/datastax-streaming-docs-site/build/site'
+  #dir: 'build/site'
+
+urls:
+  # https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+  # https://docs.antora.org/antora/latest/page/page-aliases/
+  redirect_facility: httpd
+
+  latest_version_segment_strategy: redirect:from # https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/
+  latest_version_segment: 'latest'
+
 content:
   sources:
     # DATASTAX STREAMING DOCUMENTATION MAIN PAGE
@@ -71,6 +83,12 @@ runtime:
     level: info
     failure_level: warn
 
+ui:
+  bundle:
+    url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
+    snapshot: true
+  supplemental_files: supplemental-ui
+
 asciidoc:
   attributes:
     page-pagination: ''
@@ -111,21 +129,3 @@ asciidoc:
   extensions:
     - lib/tabs-block.js
     - lib/remote-include-processor.js
-
-ui:
-  bundle:
-    url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
-    snapshot: true
-  supplemental_files: supplemental-ui
-
-output:
-  dir: '~/work/datastax-streaming-docs-site/build/site'
-  #dir: 'build/site'
-
-urls:
-  # https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
-  # https://docs.antora.org/antora/latest/page/page-aliases/
-  redirect_facility: httpd
-
-  latest_version_segment_strategy: redirect:from # https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/
-  latest_version_segment: 'latest'

--- a/antora-playbooks/antora-prod-playbook.yaml
+++ b/antora-playbooks/antora-prod-playbook.yaml
@@ -9,6 +9,18 @@ site:
     segmentIo: 'd24gQtyKIUu5mLdkp11xjfiXLhRqx0HH'
     googleAnalytics: 'UA-20879577-1'
 
+output:
+  #dir: '~/work/datastax-streaming-docs-site/build/site'
+  dir: 'build/site'
+
+urls:
+  # https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+  # https://docs.antora.org/antora/latest/page/page-aliases/
+  redirect_facility: httpd
+
+  latest_version_segment_strategy: redirect:from # https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/
+  latest_version_segment: 'latest'
+
 content:
   sources:
     # DATASTAX STREAMING DOCUMENTATION MAIN PAGE
@@ -77,6 +89,18 @@ runtime:
     level: info
     failure_level: warn
 
+output:
+  #dir: '~/work/datastax-streaming-docs-site/build/site'
+  dir: 'build/site'
+
+urls:
+  # https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+  # https://docs.antora.org/antora/latest/page/page-aliases/
+  redirect_facility: httpd
+
+  latest_version_segment_strategy: redirect:from # https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/
+  latest_version_segment: 'latest'
+
 asciidoc:
   attributes:
     page-pagination: ''
@@ -117,21 +141,3 @@ asciidoc:
   extensions:
     - lib/tabs-block.js
     - lib/remote-include-processor.js
-
-ui:
-  bundle:
-    url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
-    snapshot: true
-  supplemental_files: supplemental-ui
-
-output:
-  #dir: '~/work/datastax-streaming-docs-site/build/site'
-  dir: 'build/site'
-
-urls:
-  # https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
-  # https://docs.antora.org/antora/latest/page/page-aliases/
-  redirect_facility: httpd
-
-  latest_version_segment_strategy: redirect:from # https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/
-  latest_version_segment: 'latest'


### PR DESCRIPTION
Please consider this order change to items in the playbook, in order to put critical items nearer the top (output, urls). I've also moved up the ui-bundle, since it is a general item.