### PR TITLE
DOC-3853: Update/add support_url attribute

### DIFF
--- a/antora-playbooks/develop.yaml
+++ b/antora-playbooks/develop.yaml
@@ -98,6 +98,7 @@ asciidoc:
     external-link-icon: '&#x2197;'
     streaming_signup_url: 'https://astra.datastax.com/streaming'
     login_url: 'https://astra.datastax.com'
+    support_url: 'https://support.datastax.com'
 
     emoji-tada: "&#127881;"
     emoji-rocket: "&#128640;"

--- a/antora-playbooks/release.yaml
+++ b/antora-playbooks/release.yaml
@@ -104,6 +104,7 @@ asciidoc:
     external-link-icon: '&#x2197;'
     streaming_signup_url: 'https://astra.datastax.com/streaming'
     login_url: 'https://astra.datastax.com'
+    support_url: 'https://support.datastax.com'
 
     emoji-tada: "&#127881;"
     emoji-rocket: "&#128640;"

--- a/antora-playbooks/stage.yaml
+++ b/antora-playbooks/stage.yaml
@@ -104,6 +104,7 @@ asciidoc:
     external-link-icon: '&#x2197;'
     streaming_signup_url: 'https://astra.datastax.com/streaming'
     login_url: 'https://astra.datastax.com'
+    support_url: 'https://support.datastax.com'
 
     emoji-tada: "&#127881;"
     emoji-rocket: "&#128640;"

--- a/site-main/modules/ROOT/pages/index.adoc
+++ b/site-main/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ image::icons/using-the-astra-console.svg[icon description,40,xref=astra-streamin
 .xref:luna-streaming::index.adoc[Luna Streaming]
 ****
 --
-A production-ready distribution of Apache Pulsar with 24/7 expert enterprise support. 
+A production-ready distribution of Apache Pulsar with 24/7 expert enterprise support.
 
 * xref:luna-streaming::index.adoc[Learn more]
 * xref:luna-streaming:install-upgrade:quickstart-helm-installs.adoc[]
@@ -99,12 +99,12 @@ image::icons/migrating-apps.svg[Astra DB card icon,40]
 
 
 [sidebar.landing-card]
-.https://www.datastax.com/services/support[DataStax Support]
+.{support_url}[DataStax Support]
 ****
 --
 Get support for DataStax streaming products.
 
-* https://www.datastax.com/services/support[Contact Support]
+* {support_url}[Contact Support]
 --
 [.landing-card-body-icon]
 image::icons/security.svg[Astra DB card icon,40]


### PR DESCRIPTION
**JIRA:** https://datastax.jira.com/browse/DOC-3853

This change updates/adds the `support_url` attribute with the correct link to the DataStax Support website.