### PR TITLE
DOC-4038: Bump Redocly CLI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
         "mobx": "~6.0.4",
         "react": "~16.8.4",
         "react-dom": "~16.8.4",
-        "redoc": "~2.0.0-rc.70",
-        "redoc-cli": "~0.13.14",
         "rxjs": "~7.0.1",
         "styled-components": "~5.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "@antora/cli": "~3.1",
         "@antora/site-generator": "~3.1",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redocly/cli": "1.0.0-beta.102",
+        "@redocly/cli": "^1.2.0",
         "antora": "^3.1.1",
         "async": "~3.2.4",
         "linkinator": "~3.0.3",


### PR DESCRIPTION
Per [DOC-4038](https://datastax.jira.com/browse/DOC-4038), a vulnerability was discovered in the version of Redocly CLI currently being used in a few of our repos.

This PR bumps the version to `"@redocly/cli": "^1.2.0"` (the same version we're using in [astra-api-docs](https://github.com/riptano/astra-api-docs/blob/main/package.json#L20C5-L20C30)). It also removes the deprecated `redoc` dependencies. 

IMPORTANT: I don't know exactly how API documentation is currently being built for the Streaming docs. If the API docs are built somewhere else, steps should be taken to update/remove these dependencies in the location where they are being built.